### PR TITLE
Add netbsd 7.2 binary distribution for airport time capsule, 5th gen

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.tgz filter=lfs diff=lfs merge=lfs -text
+*.tar.gz filter=lfs diff=lfs merge=lfs -text

--- a/dists/airport_time_capsule/5th_gen/netbsd7.2/base.tgz
+++ b/dists/airport_time_capsule/5th_gen/netbsd7.2/base.tgz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7795699b366aad96933b5ff3f310222e85927c7ff16a15de3ebb585049dabc46
+size 393194915

--- a/dists/airport_time_capsule/5th_gen/netbsd7.2/comp.tgz
+++ b/dists/airport_time_capsule/5th_gen/netbsd7.2/comp.tgz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee3c8994dee3927929d89f8cda1f08f8989a7b1a329369811fca6b2435680dd8
+size 75867412

--- a/dists/airport_time_capsule/5th_gen/netbsd7.2/etc.tgz
+++ b/dists/airport_time_capsule/5th_gen/netbsd7.2/etc.tgz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f389285541fb5ad257d2d0e9394d1eebd25c1074c015f813519c45b59920a4ce
+size 584751

--- a/dists/airport_time_capsule/5th_gen/netbsd7.2/man.tgz
+++ b/dists/airport_time_capsule/5th_gen/netbsd7.2/man.tgz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dca92857768a25b4eceb2ec76c684d0871d9d33dcd97a3b640bafd1025e90a83
+size 10870193

--- a/dists/airport_time_capsule/5th_gen/netbsd7.2/misc.tgz
+++ b/dists/airport_time_capsule/5th_gen/netbsd7.2/misc.tgz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9c356480a64f7316ae20019254558cefa718c5f95794230e2eb08f77af0055d9
+size 5253457

--- a/dists/airport_time_capsule/5th_gen/netbsd7.2/text.tgz
+++ b/dists/airport_time_capsule/5th_gen/netbsd7.2/text.tgz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2a905256f527a96141a437a6376af7f4228046cae7d2fb65ee0cb2361e75d72
+size 6880586


### PR DESCRIPTION
NetBSD full binaries for Airport Time Capsule, 5th gen.